### PR TITLE
Updated HelioHost Wiki

### DIFF
--- a/features/plesk.md
+++ b/features/plesk.md
@@ -9,7 +9,7 @@ Plesk is a powerful, yet user-friendly hosting/domain manager. Plesk has a simpl
 Through Plesk \(included with all HelioHost hosting accounts\), you can
 
 * Create and manage e-mail addresses for your domain.
-* Check e-mail using RoundCube -or- alter MX records for use with another e-mail service \(such as Google Apps - doing this will cause the Plesk built-in webmail clients to stop working\)
+* Check e-mail using RoundCube -or- alter MX records for use with another e-mail service \(such as Google Workspace - doing this will cause the Plesk built-in webmail clients to stop working\)
 * Set-up e-mail clients for use with your e-mail addresses \(through POP3/SMTP\)
 * Update your HelioHost account information/password
 * Create and manage FTP accounts
@@ -21,7 +21,7 @@ Through Plesk \(included with all HelioHost hosting accounts\), you can
 * Manage zone records \(A, CNAME, TXT\) for your domain\(s\)
 * Create MySQL/PostgreSQL databases/users \(see [MySQL Databases](../management/mysql.md)\)
 * Edit SQL tables using phpMyAdmin/phpPgAdmin
-* Install software using Softaculous \(see Softaculous\)
+* Install software using Plesk Applications Installer
 * Manage Perl modules
 
 ## How do I access my Plesk?

--- a/hosting/what-heliohost-is-not.md
+++ b/hosting/what-heliohost-is-not.md
@@ -4,7 +4,7 @@ HelioHost is a free web host; it is not your one-stop gateway to running a websi
 
 ## HelioHost is NOT a Domain Registrar
 
-A domain name registrar is a service used to purchase top level domains \(TLDs\) - i.e. a .com, .org, .net, or similar website name. HelioHost DOES NOT offer domain registration. When you sign up with HelioHost, you can use a free .heliohost.org subdomain \(your domain would be yourwebsite.heliohost.org where "yourwebsite" is replaced with whatever you choose\), use a domain purchased from another registrar \(such as [GoDaddy](http://www.godaddy.com/default.aspx) or [Network Solutions](http://www.networksolutions.com/)\), or a free .tk domain \(which you can register at [dot.tk](http://dot.tk/)\)\*. HelioHost does not offer, support, or maintain any domain names.
+A domain name registrar is a service used to purchase top level domains \(TLDs\) - i.e. a .com, .org, .net, or similar website name. HelioHost DOES NOT offer domain registration. When you sign up with HelioHost, you can use a free .heliohost.org subdomain \(your domain would be yourwebsite.heliohost.org where "yourwebsite" is replaced with whatever you choose\), use a domain purchased from another registrar \(such as [GoDaddy](http://www.godaddy.com/default.aspx) or [Network Solutions](http://www.networksolutions.com/)\), or a free domain \(which you can register at [Freenom](https://www.freenom.com/)\)\*. HelioHost does not offer, support, or maintain any domain names.
 
 {% hint style="info" %}
 As a sign of thanks for HelioHost's most active members, HelioHost will purchase a domain for you with our own funds if you meet the requirements outlined [here](https://www.helionet.org/index/topic/34286-free-domain-requests-400-posts-required/).
@@ -12,7 +12,7 @@ As a sign of thanks for HelioHost's most active members, HelioHost will purchase
 
 ## HelioHost is Not a Website Designer
 
-HelioHost offers free website hosting. HelioHost does NOT create, design, or maintain your website for you, it only gives it a place to be hosted. Through cPanel, you can use Softaculous to install popular software \(such as blogging and forum platforms\) to your website, but you are responsible for ALL maintenance, design, etc.
+HelioHost offers free website hosting. HelioHost does NOT create, design, or maintain your website for you, it only gives it a place to be hosted. Through Plesk, you can use their auto-installer to install popular software \(such as blogging and forum platforms\) to your website, but you are responsible for ALL maintenance, design, etc.
 
 \*\*\*\*
 

--- a/servers/virtual/johnny.md
+++ b/servers/virtual/johnny.md
@@ -1,6 +1,6 @@
 # Johnny
 
-Johnny is similar to Ricky, but he allows dangerous services such as Java/JSP to his users. Johnny is hosted on [Sparkie](../physical/sparkie.md).\
+Johnny is similar to Ricky, but he allows dangerous services such as Python to his users. Johnny is hosted on [Sparkie](../physical/sparkie.md).\
 \
 Also, per Krydos:\
 ![](../../.gitbook/assets/image.png)


### PR DESCRIPTION
- Replaced "Google Apps" with "Google Workspace"
- Replaced "softaculous" with "Plesk Applications Installer"
- Replaced "free .tk domain \(which you can register at [dot.tk](http://dot.tk/)\)\*" with "free domain \(which you can register at [Freenom](https://www.freenom.com/)\)\*"
- Updated AutoInstaller "Through Plesk, you can use their auto-installer to install popular software \(such as blogging and forum platforms\) to your website, but you are responsible for ALL maintenance, design, etc."
- Replaced Java/JSP with Python