### PR TITLE
Update Wiki Summary menu with link to `Password Protect a Directory` tutorial

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,6 +35,7 @@
     * [Account Backups](tutorials/plesk/account-backups.md)
     * [Viewing Error Logs](tutorials/plesk/view-error-logs.md)
     * [Cron Jobs / Scheduled Tasks](tutorials/plesk/cron-jobs.md)
+    * [Password Protect a Directory](tutorials/plesk/password-protect-directory.md)
   * [Python](tutorials/python.md)
   * [Ruby on Rails](tutorials/ror.md)
   * [External DNS Hosting](tutorials/external-dns-hosting/README.md)


### PR DESCRIPTION
Adds a link to the new page created under #105 to the Wiki Summary under Tutorials > Plesk