### PR TITLE
Update Wiki Summary with updated filepath for Contributing page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -74,7 +74,7 @@
 
 * [Clear Your Cache](misc/clear-your-cache.md)
 * [WordPress](misc/wordpress.md)
-* [Contributing to the Wiki](misc/contributing.md)
+* [Contributing to the Wiki](CONTRIBUTING.md)
 * [Server Load and Uptime](misc/server-status.md)
 * [How You Can Help](misc/how-you-can-help.md)
 * [Staff](misc/staff/README.md)


### PR DESCRIPTION
Updates the Wiki Summary left-side menu to reflect that the Contributing page is in the repo root (updated by #108)