### PR TITLE
Fix link for `Converting Existing Django App page` which led to repo file

### DIFF
--- a/tutorials/django/converting-existing-django-app.md
+++ b/tutorials/django/converting-existing-django-app.md
@@ -51,7 +51,7 @@ There are two ways to configure Django to work with the mod_wsgi loader in Apach
 
 This tutorial will guide you through using the command line on your development system to convert an existing Django app for hosting on HelioHost.
 
-If you prefer not to use the command line, our brief [Django on HelioHost](./django-on-heliohost.md) tutorial may better suit your needs. 
+If you prefer not to use the command line, our brief [Django on HelioHost](django-on-heliohost.md) tutorial may better suit your needs. 
 
 The official Django 4.1 documentation [is available here](https://docs.djangoproject.com/en/4.1). We recommend following the [introduction tutorial](https://docs.djangoproject.com/en/4.1/intro/tutorial01/) to start off with. We also suggest using `virtualenv` to differentiate each Django installation for each project. The below tutorial has been designed for Linux users, but Windows users should work it out easily. 
 

--- a/tutorials/django/django-on-heliohost.md
+++ b/tutorials/django/django-on-heliohost.md
@@ -51,7 +51,7 @@ There are two ways to configure Django to work with the mod_wsgi loader in Apach
 
 This brief tutorial will guide you through setting up a Django test app without using the command line on your development system.
 
-If you already have an existing Django app or prefer to use the command line, our tutorial on [Converting an Existing Django App](./converting-existing-django-app.md) may better suit your needs.
+If you already have an existing Django app or prefer to use the command line, our tutorial on [Converting an Existing Django App](converting-existing-django-app.md) may better suit your needs.
 
 ### 1. Create a directory on your main domain called `djangotest`. 
 


### PR DESCRIPTION
Sibling links work with a leading `./` in the testing environment, but sometimes inconsistently lead to the GitHub repo file instead of the Wiki page.