### PR TITLE
Fix link for Django as there are 2 tutorials now

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -82,7 +82,7 @@ To request that we reset your account so you can start over, send an email **fro
 
 Once your account has been reset, you will receive an email with a link to restart your account. **You will have 7 days to use the link.** If you don't use the link to restart your account within 7 days, you will need to signup for a brand new account.
 
-If you had WSGI Control Access on your account for [Flask](tutorials/flask.md) or [Django](tutorials/django.md) and you want this re-enabled after the reset, you will need to re-request WSGI Control Access after the reset has been completed. By default, account resets will disable WSGI Control Access.
+If you had WSGI Control Access on your account for [Flask](tutorials/flask.md) or [Django](tutorials/django/README.md) and you want this re-enabled after the reset, you will need to re-request WSGI Control Access after the reset has been completed. By default, account resets will disable WSGI Control Access.
 
 ### VPS Rebuilds
 


### PR DESCRIPTION
Links that led to django.md must now go to the higher-level django/README.md index page, since there are 2 tutorials in that section.