### PR TITLE
Fix link for Django as there are 2 tutorials now

### DIFF
--- a/features/python.md
+++ b/features/python.md
@@ -6,7 +6,7 @@ Python is an easy to learn, powerful programming language. It has efficient high
 
 ## Django
 
-How to create a [Django](../tutorials/django.md) application.  
+How to create a [Django](../tutorials/django/README.md) application.  
 
 ## Python
 


### PR DESCRIPTION
Links that led to django.md must now go to the higher-level django/README.md index page, since there are 2 tutorials in that section.