### PR TITLE
Add link to Account Backups page & fix link to Django tutorial index page

### DIFF
--- a/hosting/what-heliohost-offers.md
+++ b/hosting/what-heliohost-offers.md
@@ -5,7 +5,7 @@
 * Access to [Plesk](../tutorials/plesk/README.md)
 * Ability for users to create, download, and schedule [Account Backups](../tutorials/plesk/account-backups.md)
 * Ability to edit [A, CNAME, TXT, and MX records](../tutorials/dns-record-management/heliohost-dns-records/README.md)
-* [1000 MB of Disk Space](../features/storage.md)
+* [1000 MB of Disk Space](../features/storage.md) with the option to [donate for increased storage of up to 6000 MB total](../accounts/donation-increase-storage.md)
 * [Unlimited Email Accounts](../features/unlimited-email-accounts.md)
 * Unlimited Mailing Lists
 * [Unlimited Bandwidth](../features/unlimited-bandwidth.md)

--- a/hosting/what-heliohost-offers.md
+++ b/hosting/what-heliohost-offers.md
@@ -3,6 +3,7 @@
 ## HelioHost offers free web hosting for all. Every account includes:
 
 * Access to [Plesk](../tutorials/plesk/README.md)
+* Ability for users to create, download, and schedule [Account Backups](../tutorials/plesk/account-backups.md)
 * Ability to edit [A, CNAME, TXT, and MX records](../tutorials/dns-record-management/heliohost-dns-records/README.md)
 * [1000 MB of Disk Space](../features/storage.md)
 * [Unlimited Email Accounts](../features/unlimited-email-accounts.md)

--- a/hosting/what-heliohost-offers.md
+++ b/hosting/what-heliohost-offers.md
@@ -24,7 +24,7 @@
 * [Java / JSP](../features/java.md)
 * [Node.js](../tutorials/node.js/README.md)
 * [PHP](../features/php.md)
-* [Python](../features/python.md), [Django](../tutorials/django.md), and [Flask](../tutorials/flask.md)
+* [Python](../features/python.md), [Django](../tutorials/django/README.md), and [Flask](../tutorials/flask.md)
 * [Perl](../tutorials/perl.md)
 * [Ruby on Rails](../tutorials/ror.md)
 

--- a/hosting/what-heliohost-offers.md
+++ b/hosting/what-heliohost-offers.md
@@ -3,9 +3,9 @@
 ## HelioHost offers free web hosting for all. Every account includes:
 
 * Access to [Plesk](../tutorials/plesk/README.md)
-* Ability for users to create, download, and schedule [Account Backups](../tutorials/plesk/account-backups.md)
+* Users can create, download, and schedule [Account Backups](../tutorials/plesk/account-backups.md)
 * Ability to edit [A, CNAME, TXT, and MX records](../tutorials/dns-record-management/heliohost-dns-records/README.md)
-* [1000 MB of Disk Space](../features/storage.md) with the option to [donate for increased storage of up to 6000 MB total](../accounts/donation-increase-storage.md)
+* [1000 MB of Disk Space](../features/storage.md) (with the option to [donate for increased storage of up to 6000 MB total](../accounts/donation-increase-storage.md))
 * [Unlimited Email Accounts](../features/unlimited-email-accounts.md)
 * Unlimited Mailing Lists
 * [Unlimited Bandwidth](../features/unlimited-bandwidth.md)

--- a/hosting/what-heliohost-offers.md
+++ b/hosting/what-heliohost-offers.md
@@ -14,7 +14,7 @@
 * Unlimited [MySQL](../management/mysql.md) / [PostgreSQL](../features/postgresql.md) / [SQLite](../features/sqlite.md) Databases
 * Access to [phpMyAdmin](../management/mysql.md#managing-the-database-with-phpmyadmin)
 * Ability to add [Perl](../tutorials/perl.md) Modules
-* [Free SSL](/management/ssl.md) with `SSL It!`
+* [Free SSL](../management/ssl.md) with `SSL It!`
 * [Softaculous](../features/softaculous.md) (Easy installation of popular software such as blogging and forum platforms)
 
 ## HelioHost accounts can use the following scripting languages:


### PR DESCRIPTION
Links that led to django.md must now go to the higher-level django/README.md index page, since there are 2 tutorials in that section.